### PR TITLE
Add an API: getMembershipFromHardLinkedCredential

### DIFF
--- a/__test__/index.test.js
+++ b/__test__/index.test.js
@@ -251,3 +251,15 @@ test('getPublicMilestones returns list of current milestones', () => {
     return destiny.getPublicMilestones()
         .then(res => expect(res.ErrorCode).toEqual(1));
 });
+
+test('getMembershipFromHardLinkedCredential returns a membership from steam id ', () => {
+    return destiny.getMembershipFromHardLinkedCredential('76561198253960732')
+        .then(res => {
+            expect(res.ErrorCode).toEqual(1);
+            expect(res.Response).toHaveProperty('membershipType');
+            expect(res.Response).toHaveProperty('membershipType');
+            expect(res.Response.membershipType).toEqual(3); // always 3(Steam) for now
+            expect(res.Response).toHaveProperty('membershipId');
+            expect(res.Response).toHaveProperty('CrossSaveOverriddenType');
+        });
+})

--- a/lib/destiny-2-api.js
+++ b/lib/destiny-2-api.js
@@ -346,6 +346,16 @@ class Destiny2API {
         this.options.method = 'GET';
         return promiseRequest(this.options).then(res => formatJson(res));
     }
+
+    /**
+     * Get member ship id from steam id(bungie only support steamid64 for now)
+     * @param {string|number} steamId64 
+     */
+    getMembershipFromHardLinkedCredential(steamId64) {
+        this.options.path = `/Platform/User/GetMembershipFromHardLinkedCredential/SteamId/${steamId64}`;
+        this.options.method = 'GET';
+        return promiseRequest(this.options).then(res => formatJson(res));
+    }
 }
 
 module.exports = Destiny2API;


### PR DESCRIPTION
## TL;DR;
Use SteamID64 to get membership id accurately.

Most players on PC are using Steam, I think this API is needed.